### PR TITLE
Fix port status

### DIFF
--- a/uhubctl/__init__.py
+++ b/uhubctl/__init__.py
@@ -134,7 +134,7 @@ class Port:
         status = None
         pattern = re.compile(f"  Port {self.port_number}: \d{{4}} (power|off)")
 
-        args = ["-l", self.hub.path, "-p", self.port_number]
+        args = ["-l", self.hub.path, "-p", str(self.port_number)]
         for line in _uhubctl(args):
             reg = pattern.match(line)
 
@@ -148,7 +148,7 @@ class Port:
 
     @status.setter
     def status(self, status: bool) -> None:
-        args = ["-l", self.hub.path, "-p", self.port_number, "-a"]
+        args = ["-l", self.hub.path, "-p", str(self.port_number), "-a"]
 
         if status:
             args.append("on")


### PR DESCRIPTION
Port status is broken since 203459dd2f2cece19d7da7d5393883a84526cb19 as it sets the datatype of `port_number` to `int` instead of `str`. This has been fixed by casting `port_number` to `str` when used in command arguments.
