### PR TITLE
fix: make port handling more robust

### DIFF
--- a/uhubctl/usb.py
+++ b/uhubctl/usb.py
@@ -94,7 +94,7 @@ class Hub:
         """
         Discover ports for this hub instance
         """
-        pattern = re.compile(r"  Port (\d+): \d{4} (power|off)")
+        pattern = re.compile(r"  Port (\d+): \d{4} ")
 
         for line in _uhubctl(["-l", self.path]):
             regex = pattern.match(line)
@@ -131,7 +131,7 @@ class Port:
         """
         status = None
         pattern = re.compile(
-            fr"  Port {self.port_number}: \d{{4}} (power|off)")
+            fr"  Port {self.port_number}: \d{{4}} (power|off|indicator)")
 
         args = ["-l", self.hub.path, "-p", str(self.port_number)]
         for line in _uhubctl(args):


### PR DESCRIPTION
The old approach of port discovery and status handling relies on a certain format of uhubctl output. It turned out that this is kinda fragile, because it does not always contain the keyword 'off' for a disabled port (eg. when indicator status is present). Fix this by removing the status from discovery and adding 'indicator' to status handling.

Signed-off-by: Nicolai Buchwitz <nb@tipi-net.de>