### PR TITLE
pyproject.toml: Use setuptools>=64 if python>=3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,4 +3,6 @@ line-length = 120
 include = '\.pyi?$'
 
 [build-system]
-requires = ["setuptools<64", "wheel"]
+requires = ["setuptools<64; python_version < '3.12'",
+            "setuptools>=64; python_version >= '3.12'",
+            "wheel"]


### PR DESCRIPTION
Hi @nbuchwitz,

First of all, thank you for the awesome project! I use it at my University to turn on and off FPGA development boards on Continuous Integration pipelines.

When trying to install `python3-uhubctl` using python 3.12, I get the following error:

```
AttributeError: module 'pkgutil' has no attribute 'ImpImporter'. Did you mean: 'zipimporter'?
```

This seems to happen due to the `setuptools` version being too old.

This Pull Request solves the issue by using a recent `setuptools` version, but only if the python version is `3.12` or higher.

I have tried it both with python 3.10 and python 3.12 without any issues (neither during installation nor during switching USB ports)

Thank you!

Hipólito